### PR TITLE
Add PyTests tests for model logic

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,17 @@
+name: PyTest
+on: pull_request
+jobs:
+  pytest:
+    name: Run the application's tests with PyTest
+    runs-on: ubuntu-20.04
+    container: fedora:32
+    steps:
+      - name: Install Pipenv and Git
+        run: dnf install -y pipenv git
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup environment
+        run: pipenv sync --dev
+      - name: Run PyTest
+        run: pipenv run pytest -v
+

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 flake8 = "*"
+pytest-django = "*"
 
 [packages]
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6fffd33ea4c7101a8d92c3b874bdb5da45821539a073ab0c6419a65bf8387efd"
+            "sha256": "31adbc170dc03695bbefb9c68ecba860c572e3e8366b7d4fe2b98e8009f2ce80"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,6 +64,14 @@
         }
     },
     "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.4.0"
+        },
         "flake8": {
             "hashes": [
                 "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
@@ -72,12 +80,43 @@
             "index": "pypi",
             "version": "==4.0.1"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -94,6 +133,38 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.5"
+        },
+        "pytest-django": {
+            "hashes": [
+                "sha256:c60834861933773109334fe5a53e83d1ef4828f2203a1d6a0fa9972f4f75ab3e",
+                "sha256:d9076f759bb7c36939dbdd5ae6633c18edfc2902d1a69fdbefd2426b970ce6c2"
+            ],
+            "index": "pypi",
+            "version": "==4.5.2"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
         }
     }
 }

--- a/accounts/migrations/0002_test_data.py
+++ b/accounts/migrations/0002_test_data.py
@@ -4,6 +4,7 @@ from django.db import migrations, transaction
 class Migration(migrations.Migration):
 
     dependencies = [
+        ('auth', '__latest__'),
         ('accounts', '0001_initial'),
     ]
 

--- a/msgboard/migrations/0005_test_data.py
+++ b/msgboard/migrations/0005_test_data.py
@@ -5,10 +5,15 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('msgboard', '0004_usermessage'),
-        ('accounts', '0002_test_data')
+        ('accounts', '0002_test_data'),
     ]
 
     def generate_data(apps, schema_editor):
+        from django.conf import settings
+
+        if not settings.DEBUG:
+            return
+
         from accounts.models import Account
         from msgboard.models import UserMessage
 

--- a/msgboard/models.py
+++ b/msgboard/models.py
@@ -10,7 +10,14 @@ class Message(models.Model):
     date = models.DateTimeField(default=timezone.now)
 
 
+class UserMessagesManager(models.Manager):
+    def main_feed(self):
+        return self.order_by('-date').select_related()
+
+
 class UserMessage(models.Model):
     author = models.ForeignKey(to=Account, on_delete=models.CASCADE)
     text = models.TextField()
     date = models.DateTimeField(default=timezone.now)
+
+    messages = UserMessagesManager()

--- a/msgboard/tests.py
+++ b/msgboard/tests.py
@@ -1,3 +1,16 @@
-# from django.test import TestCase
+import pytest
+from django.db.models.query import QuerySet
 
-# Create your tests here.
+from .models import UserMessage
+
+
+@pytest.mark.django_db()
+def test_main_feed():
+    out = UserMessage.messages.main_feed()
+    assert isinstance(out, QuerySet)
+    assert all(isinstance(m, UserMessage) for m in out)
+    assert list(out.values_list('author__user__username', 'text')) == [
+        ('zombie', 'Braaaiiiinz!'),
+        ('robot', 'Beep Beep, Boop Boop!'),
+        ('woman1', 'Hi!'),
+    ]

--- a/msgboard/views.py
+++ b/msgboard/views.py
@@ -4,7 +4,6 @@ from .forms import UserMessageForm
 
 
 def board(request):
-    messages = UserMessage.objects.order_by('-date').select_related()
     if request.user.is_authenticated:
         if request.method == "POST":
             form = UserMessageForm(request.POST)
@@ -17,6 +16,7 @@ def board(request):
             form = UserMessageForm()
     else:
         form = None
+    messages = UserMessage.messages.main_feed()
     return render(request, 'msgboard/board.html', {
         'messages': messages,
         'form': form,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = beyond_tutorial.settings
+django_debug_mode = true
+python_files = tests.py test_*.py *_tests.py
+


### PR DESCRIPTION
- Added the `pytest-django` package
- Moved the logic of getting the list of messages to display on the
  main feed from the view layer to the model layer
- Added a test for the feed message list
- Added configuration to run PyTest tests in GitHub actions

Signed-off-by: Barak Korren <bkorren@redhat.com>