### PR TITLE
Fix: Make provisioned test server not crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,9 +131,6 @@ dmypy.json
 # Vagrant
 .vagrant/
 
-# Logs
-nohup.out
-
 # DB:
 db.sqlite3
 

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,7 @@ pipenv sync
 # Run database migrations
 pipenv run python manage.py migrate
 
-# run our app. Nohup and "&" are used to let the setup script finish
-# while our app stays up. The app logs will be collected in nohup.out
-nohup pipenv run python manage.py runserver 0.0.0.0:8000 &
+# run our app. setsit, the parentheses and "&" are used to perform a "double
+# fork" so that out app stays up after the setup script finishes.
+# The app logs are redirected to the `runserver.log` file.
+(setsid pipenv run python manage.py runserver 0.0.0.0:8000 > runserver.log 2>&1 &)


### PR DESCRIPTION
The way we launched the Django dev server in the provision script had
caused it to crash every time we change the code. With the new command
it reloads the code as it needs to.